### PR TITLE
Updated doc for PhantoJsDriver#executePhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ you shouldn't need anything else to get started.
 ## (Java) Bindings
 
 This project provides WebDriver bindings for Java under the name _PhantomJSDriver_.
-[Here is the JavaDoc](https://cdn.rawgit.com/detro/ghostdriver/master/binding/java/docs/javadoc/index.html).
+[Here is the JavaDoc for this fork](https://cdn.rawgit.com/codeborne/ghostdriver/master/binding/java/docs/javadoc/index.html).
 
 Bindings for other languages (C#, Python, Ruby, ...) are developed and maintained
 under the same name within the [Selenium project](http://docs.seleniumhq.org/docs/) itself.

--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriver.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriver.java
@@ -143,11 +143,11 @@ public class PhantomJSDriver extends RemoteWebDriver implements TakesScreenshot 
      * Execute a PhantomJS fragment.  Provides extra functionality not found in WebDriver
      * but available in PhantomJS.
      * <p/>
-     * See the <a href="http://phantomjs.org/api/">PhantomJS API<</a>
+     * See the <a href="http://phantomjs.org/api/">PhantomJS API</a>
      * for details on what is available.
      * <p/>
-     * A 'page' variable pointing to currently selected page is available for use.
-     * If there is no page yet, one is created.
+     * Use <code>this</code> to access the <a href="http://phantomjs.org/api/webpage/">phantom 'page' variable</a>
+     * pointing to current page. If there is no page yet, one is created.
      * <p/>
      * When overriding any callbacks be sure to wrap in a try/catch block, as failures
      * may cause future WebDriver calls to fail.
@@ -155,6 +155,39 @@ public class PhantomJSDriver extends RemoteWebDriver implements TakesScreenshot 
      * Certain callbacks are used by GhostDriver (the PhantomJS WebDriver implementation)
      * already.  Overriding these may cause the script to fail.  It's a good idea to check
      * for existing callbacks before overriding.
+     * <p/>
+     * Example usages:
+     * <pre>
+     * {@code
+     * // results are returned back
+     * Object result = phantom.executePhantomJS("return 1 + 1");
+     * System.out.println(result); // => 2
+     * }
+     * </pre>
+     *
+     * <pre>
+     * {@code
+     * // you can pass arguments to the script
+     * Object result = phantom.executePhantomJS("return arguments[0] + arguments[0]", new Long(1));
+     * System.out.println(result); // => 2
+     * }
+     * </pre>
+     *
+     * <pre>
+     * {@code
+     * // phantom page API is accessible as 'this'
+     * Object result  = driver.executePhantomJS(
+     *     "var page = this;" +
+     *     "page.onConsoleMessage = function(msg) {" +
+     *         "console.log('BROWSER CONSOLE:', msg);" +
+     *     "};" +
+     *     "page.onInitialized = function () { " +
+     *         "page.evaluate(function () { " +
+     *             "console.log('Hello world!')" +
+     *         "})" +
+     *     "}");
+     * </pre>
+     *
      *
      * @param script The fragment of PhantomJS JavaScript to execute.
      * @param args List of arguments to pass to the function that the script is wrapped in.


### PR DESCRIPTION
Current documentation has a mistake (saying that ‘page’ var is
available, while in fact it is available as ‘this’) that had cost me 2
days of debugging. Hopefully updated doc will save this time for
someone else :)

Also updated the README to point to the javadoc for the fork rather
than main repo.

Sorry, I didn’t generate the doc. I am not a Java guy, and got confused
in gradle and javadoc versions, I hope you can do it in 5 minutes what I
failed to do in an hour.
