### PR TITLE
replace deprecated (now removed) CommandLine #find method

### DIFF
--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
@@ -33,7 +33,7 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.net.PortProber;
-import org.openqa.selenium.os.CommandLine;
+import org.openqa.selenium.os.ExecutableFinder;
 import org.openqa.selenium.remote.service.DriverService;
 
 import java.io.File;
@@ -229,7 +229,7 @@ public class PhantomJSDriverService extends DriverService {
                 desiredCapabilities.getCapability(PHANTOMJS_EXECUTABLE_PATH_PROPERTY) != null) {
             phantomjspath = (String) desiredCapabilities.getCapability(PHANTOMJS_EXECUTABLE_PATH_PROPERTY);
         } else {
-            phantomjspath = CommandLine.find(PHANTOMJS_DEFAULT_EXECUTABLE);
+            phantomjspath = new ExecutableFinder().find(PHANTOMJS_DEFAULT_EXECUTABLE);
             phantomjspath = System.getProperty(PHANTOMJS_EXECUTABLE_PATH_PROPERTY, phantomjspath);
         }
 


### PR DESCRIPTION
For selenium-standalone 3.0.2, the deprecated CommandLine #find method is removed which the ghostdriver bindings rely on (see this commit https://github.com/SeleniumHQ/selenium/commit/3856302060947bf92367f7e1ec6b966e8760c74f). This is the replacement for that method. It cannot be built right now, however, as ExecutableFinder was only just made public in that same commit. This fix will have to coincide with selenium 3.0.2 release.