### PR TITLE
Update selenium dependencies

### DIFF
--- a/binding/java/build.gradle
+++ b/binding/java/build.gradle
@@ -60,7 +60,7 @@ ext.projectCreator          = "Ivan De Marino (https://github.com/detro)"
 ext.seleniumVersion         = "3.1.0"
 
 dependencies {
-    ["selenium-java", "selenium-remote-driver"].each {
+    ["selenium-api", "selenium-remote-driver"].each {
         compile "org.seleniumhq.selenium:$it:$seleniumVersion"
     }
 }


### PR DESCRIPTION
We rely on the remote and core APIs. The "selenium-java" dep
is provided by the selenium project as a handy way of pulling
in every driver that makes sense. This means that there's a
circular dependency (phantomjs -> selenium-java -> phantomjs)
which is easy to break.